### PR TITLE
Support for Bonaire-based cards

### DIFF
--- a/HawaiBiosEdit/MainWindow.xaml.cs
+++ b/HawaiBiosEdit/MainWindow.xaml.cs
@@ -33,7 +33,7 @@ namespace HawaiBiosReader
 
         Byte[] romStorageBuffer;
 
-        string[] supportedDevIDs = new string[] { "67A0", "67A1", "67A2", "67A8", "67A9", "67AA", "67B0", "67B1", "67B9" };
+        string[] supportedDevIDs = new string[] { "67A0", "67A1", "67A2", "67A8", "67A9", "67AA", "67B0", "67B1", "67B9", "665C", "665D", "6658", "665F" };
 
         // unknown table offsets
         int headerPosition;
@@ -129,11 +129,14 @@ namespace HawaiBiosReader
                     indicator.Text = "0x" + getNBitValueFromPosition(8, pciInfoPosition + 21, romStorageBuffer).ToString("X");
                     reserved.Text = "0x" + getNBitValueFromPosition(16, pciInfoPosition + 22, romStorageBuffer).ToString("X");
 
+                    MessageBoxResult result = MessageBoxResult.Yes;
+
                     if (!supportedDevIDs.Contains(devIDstr))
                     {
-                        MessageBoxResult result = MessageBox.Show("Unsupported ROM", "Error", MessageBoxButton.OK);
+                        result = MessageBox.Show("Unsupported ROM - Continue?", "Warning", MessageBoxButton.YesNo, MessageBoxImage.Warning);
                     }
-                    else
+
+                    if (result == MessageBoxResult.Yes)
                     {
                         powerTableSize = getNBitValueFromPosition(16, powerTablePosition, romStorageBuffer);
                         powerTablesize.Text = powerTableSize.ToString();

--- a/README.md
+++ b/README.md
@@ -20,11 +20,18 @@ Binary (exe) files is in Releasebin folder, [link to the latest release here](ht
 
 #### Supported cards
 
+Generally this editor supports editing BIOS ROMs of the GCN2 generation of GPUs, namely Hawaii and Bonaire.
+
 * R9 390/R9 390X 8GB
 * R9 290/R9 290X reference 4GB/8GB
 * R9 295X2 reference (no fantable yet)
+* R7 360
+* R7 260/R7 260X
+* HD 7790
 * FirePro W9100
 * FirePro W8100 - partial support
+
+If you try to load an unsupported ROM there is an option to continue anyway, use at your own risk.
 
 If your card's ROM is not supported, then send me PM or write here on github and I will try to fix it :)
 


### PR DESCRIPTION
I added support for Bonaire-based cards (was easy since they are part of the same GCN2 generation, just needed to add the device IDs) and also added a dialog option to continue editing unsupported device IDs. This should be used at the users own risk but may prove useful. Note that while this allows reading Tonga ROMs, they aren't read correctly at the moment. I didn't commit a new binary incorporating the changes. Generally the releases feature of Github should be used for binary releases.